### PR TITLE
Fix A75 Pro identifier, general runtime check overhaul

### DIFF
--- a/js/functions.js
+++ b/js/functions.js
@@ -27,7 +27,10 @@ async function getFirmwareEntryFor(keyboard) {
 
     // the anchor in question is the a in the 4th column of the row with _blank target
     let row = FindDeviceRow(tables[0], keyboard.websiteName);
-
+    if (row == null) {
+        console.log("no device found")
+        return null;
+    }
     let nameColumn = row.children[0];
     let name = nameColumn.textContent.trim();
 
@@ -89,6 +92,12 @@ async function fetchFirmwareDownloadPage() {
  */
 function FindDeviceRow(table, keyboardName) {
     // table -> tbody -> trs
+
+    if(keyboardName == null) {
+        console.log("Undefined keyboard")
+        return;
+    }
+
     const rows = table.firstElementChild.children;
     let result;
     let found = false;

--- a/js/script.js
+++ b/js/script.js
@@ -100,6 +100,9 @@ async function checkUpdate() {
 
         if (firmwareEntry === null) {
             statusContainer.textContent = "No firmware entry found";
+            if (websiteName == null) {
+                statusContainer.textContent = "Unknown Keyboard"
+            }
         } else {
             // show the current and latest firmware versions
             currentFirmwareVersionContainer.parentElement.classList.remove("hidden");

--- a/js/script.js
+++ b/js/script.js
@@ -1,7 +1,7 @@
 const nameConversion = {
     "Drunkdeer A75 US": "A75 ANSI",
     "Drunkdeer A75 ISO": "A75 ISO",
-    "Drunkdeer A75 PRO": "A75 Pro",
+    "Drunkdeer A75 Pro US": "A75 Pro",
     "Drunkdeer G65": "G65",
     "Drunkdeer G60": "G60",
 }


### PR DESCRIPTION
the productName from HIDDevice of the A75 Pro is actually `"Drunkdeer A75 Pro US"`
